### PR TITLE
Remove /var/log/messages from syslog config.

### DIFF
--- a/catch-all-inputs.d/syslog.conf
+++ b/catch-all-inputs.d/syslog.conf
@@ -1,7 +1,7 @@
 <source>
   type tail
   format none
-  path /var/log/syslog,/var/log/messages
+  path /var/log/syslog
   pos_file /var/tmp/fluentd.syslog.pos
   read_from_head true
   tag syslog


### PR DESCRIPTION
The default rsyslog.conf file on GCE Debian VMs has:

_._;auth,authpriv.none      -/var/log/syslog
_.=info;_.=notice;*.=warn;\
    auth,authpriv.none;\
    cron,daemon.none;\
    mail,news.none      -/var/log/messages

This makes /var/log/messages a subset of /var/log/syslog, and ingesting
both leads to duplicate log entries.
