### PR TITLE
move pos_files to /var/lib/google-fluentd/pos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,14 @@ PACKAGE_VERSION=0.2
 BUILD_DIR=build
 
 DEB_PACKAGE_DIR=${BUILD_DIR}/deb/${PACKAGE_NAME}-${PACKAGE_VERSION}
-DEB_FILES_DIR=${DEB_PACKAGE_DIR}/files/etc/${BASE_PACKAGE_NAME}
+DEB_FILES_BASE=${DEB_PACKAGE_DIR}/files
+DEB_FILES_DIR=${DEB_FILES_BASE}/etc/${BASE_PACKAGE_NAME}
+DEB_POS_FILES_DIR=${DEB_FILES_BASE}/var/lib/${BASE_PACKAGE_NAME}/pos
 
 RPM_PACKAGE_DIR=${BUILD_DIR}/el/${PACKAGE_NAME}-${PACKAGE_VERSION}
-EL_FILES_DIR=${RPM_PACKAGE_DIR}/files/etc/${BASE_PACKAGE_NAME}
+EL_FILES_BASE=${RPM_PACKAGE_DIR}/files
+EL_FILES_DIR=${EL_FILES_BASE}/etc/${BASE_PACKAGE_NAME}
+EL_POS_FILES_DIR=${EL_FILES_BASE}/var/lib/${BASE_PACKAGE_NAME}/pos
 
 all: pkg tar
 
@@ -36,15 +40,21 @@ el-tar: populate-el
 	    -czf ${PACKAGE_NAME}-${PACKAGE_VERSION}.el.tar.gz .
 
 populate-deb:
+	# populate config files
 	mkdir -p ${DEB_FILES_DIR}
 	cp -a configs/* ${DEB_FILES_DIR}
+	# create the directory used for "pos_file"s
+	mkdir -p ${DEB_POS_FILES_DIR}
 
-# Note: collect /var/log/messages on RH since syslog does not exist.
 populate-el:
+	# populate config files
 	mkdir -p ${EL_FILES_DIR}
 	cp -a configs/* ${EL_FILES_DIR}
+	# collect /var/log/messages on RH since syslog does not exist.
 	sed -i -e 's/path \/var\/log\/syslog/path \/var\/log\/messages/' \
 	    ${EL_FILES_DIR}/config.d/syslog.conf
+	# create the directory used for "pos_file"s
+	mkdir -p ${EL_POS_FILES_DIR}
 
 clean:
 	rm -rf *.tar.gz ${BUILD_DIR}

--- a/configs/config.d/apache.conf
+++ b/configs/config.d/apache.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/log/apache*/access.log,/var/log/httpd/access.log
-  pos_file /var/tmp/fluentd.apache-access.pos
+  pos_file /var/lib/google-fluentd/pos/apache-access.pos
   read_from_head true
   tag apache-access
 </source>
@@ -11,7 +11,7 @@
   type tail
   format none
   path /var/log/apache*/error.log,/var/log/httpd/error.log
-  pos_file /var/tmp/fluentd.apache-error.pos
+  pos_file /var/lib/google-fluentd/pos/apache-error.pos
   read_from_head true
   tag apache-error
 </source>

--- a/configs/config.d/cassandra.conf
+++ b/configs/config.d/cassandra.conf
@@ -3,7 +3,7 @@
   format none
   # Current (v2.1) name of cassandra log.
   path /var/log/cassandra/system.log
-  pos_file /var/tmp/fluentd.cassandra-system.pos
+  pos_file /var/lib/google-fluentd/pos/cassandra-system.pos
   read_from_head true
   tag cassandra
 </source>
@@ -13,7 +13,7 @@
   format none
   # Legacy name of cassandra log.
   path /var/log/cassandra/cassandra.log
-  pos_file /var/tmp/fluentd.cassandra.pos
+  pos_file /var/lib/google-fluentd/pos/cassandra.pos
   read_from_head true
   tag cassandra
 </source>
@@ -22,7 +22,7 @@
   type tail
   format none
   path /var/log/cassandra/output.log
-  pos_file /var/tmp/fluentd.cassandra-output.pos
+  pos_file /var/lib/google-fluentd/pos/cassandra-output.pos
   read_from_head true
   tag cassandra-output
 </source>

--- a/configs/config.d/chef.conf
+++ b/configs/config.d/chef.conf
@@ -4,7 +4,7 @@
   type tail
   format none
   path /var/log/chef-server/bookshelf/current
-  pos_file /var/tmp/fluentd.chef-bookshelf.pos
+  pos_file /var/lib/google-fluentd/pos/chef-bookshelf.pos
   read_from_head true
   tag chef-bookshelf
 </source>
@@ -13,7 +13,7 @@
   type tail
   format none
   path /var/log/chef-server/chef-expander/current
-  pos_file /var/tmp/fluentd.chef-expander.pos
+  pos_file /var/lib/google-fluentd/pos/chef-expander.pos
   read_from_head true
   tag chef-expander
 </source>
@@ -22,7 +22,7 @@
   type tail
   format none
   path /var/log/chef-server/chef-pedant/http-traffic.log
-  pos_file /var/tmp/fluentd.chef-pedant-http-traffic.pos
+  pos_file /var/lib/google-fluentd/pos/chef-pedant-http-traffic.pos
   read_from_head true
   tag chef-pedant-http-traffic
 </source>
@@ -31,7 +31,7 @@
   type tail
   format none
   path /var/log/chef-server/chef-server-webui/current
-  pos_file /var/tmp/fluentd.chef-server-webui.pos
+  pos_file /var/lib/google-fluentd/pos/chef-server-webui.pos
   read_from_head true
   tag chef-server-webui
 </source>
@@ -40,7 +40,7 @@
   type tail
   format none
   path /var/log/chef-server/chef-solr/current
-  pos_file /var/tmp/fluentd.chef-solr.pos
+  pos_file /var/lib/google-fluentd/pos/chef-solr.pos
   read_from_head true
   tag chef-solr
 </source>
@@ -49,7 +49,7 @@
   type tail
   format none
   path /var/log/chef-server/erchef/current
-  pos_file /var/tmp/fluentd.chef-erchef-current.pos
+  pos_file /var/lib/google-fluentd/pos/chef-erchef-current.pos
   read_from_head true
   tag chef-erchef-current
 </source>
@@ -58,7 +58,7 @@
   type tail
   format none
   path /var/log/chef-server/erchef/erchef.log.1
-  pos_file /var/tmp/fluentd.chef-erchef.pos
+  pos_file /var/lib/google-fluentd/pos/chef-erchef.pos
   read_from_head true
   tag chef-erchef
 </source>
@@ -67,7 +67,7 @@
   type tail
   format none
   path /var/log/chef-server/nginx/access.log
-  pos_file /var/tmp/fluentd.chef-nginx-access.pos
+  pos_file /var/lib/google-fluentd/pos/chef-nginx-access.pos
   read_from_head true
   tag chef-nginx-access
 </source>
@@ -76,7 +76,7 @@
   type tail
   format none
   path /var/log/chef-server/nginx/error.log
-  pos_file /var/tmp/fluentd.chef-nginx-error.pos
+  pos_file /var/lib/google-fluentd/pos/chef-nginx-error.pos
   read_from_head true
   tag chef-nginx-error
 </source>
@@ -85,7 +85,7 @@
   type tail
   format none
   path /var/log/chef-server/nginx/rewrite-port-80.log
-  pos_file /var/tmp/fluentd.chef-nginx-rewrite-port-80.pos
+  pos_file /var/lib/google-fluentd/pos/chef-nginx-rewrite-port-80.pos
   read_from_head true
   tag chef-nginx-rewrite-port-80
 </source>
@@ -94,7 +94,7 @@
   type tail
   format none
   path /var/log/chef-server/postgresql/current
-  pos_file /var/tmp/fluentd.chef-postgresql.pos
+  pos_file /var/lib/google-fluentd/pos/chef-postgresql.pos
   read_from_head true
   tag chef-postgresql
 </source>
@@ -103,7 +103,7 @@
   type tail
   format none
   path /var/log/chef-server/rabbitmq/current
-  pos_file /var/tmp/fluentd.chef-rabbitmq.pos
+  pos_file /var/lib/google-fluentd/pos/chef-rabbitmq.pos
   read_from_head true
   tag chef-rabbitmq
 </source>

--- a/configs/config.d/gitlab.conf
+++ b/configs/config.d/gitlab.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /home/git/gitlab/log/application.log,
-  pos_file /var/tmp/fluentd.gitlab-application.pos
+  pos_file /var/lib/google-fluentd/pos/gitlab-application.pos
   read_from_head true
   tag gitlab-application
 </source>
@@ -11,7 +11,7 @@
   type tail
   format none
   path /home/git/gitlab/log/production.log,
-  pos_file /var/tmp/fluentd.gitlab-production.pos
+  pos_file /var/lib/google-fluentd/pos/gitlab-production.pos
   read_from_head true
   tag gitlab-production
 </source>
@@ -20,7 +20,7 @@
   type tail
   format none
   path /home/git/gitlab/log/sidekiq.log,
-  pos_file /var/tmp/fluentd.gitlab-sidekiq.pos
+  pos_file /var/lib/google-fluentd/pos/gitlab-sidekiq.pos
   read_from_head true
   tag gitlab-sidekiq
 </source>
@@ -29,7 +29,7 @@
   type tail
   format none
   path /home/git/gitlab/log/unicorn.stdout.log,
-  pos_file /var/tmp/fluentd.gitlab-unicorn-stdout.pos
+  pos_file /var/lib/google-fluentd/pos/gitlab-unicorn-stdout.pos
   read_from_head true
   tag gitlab-unicorn-stdout
 </source>
@@ -38,7 +38,7 @@
   type tail
   format none
   path /home/git/gitlab/log/unicorn.stderr.log,
-  pos_file /var/tmp/fluentd.gitlab-unicorn-stderr.pos
+  pos_file /var/lib/google-fluentd/pos/gitlab-unicorn-stderr.pos
   read_from_head true
   tag gitlab-unicorn-stderr
 </source>
@@ -47,7 +47,7 @@
   type tail
   format none
   path /home/git/gitlab/log/githost.log,
-  pos_file /var/tmp/fluentd.gitlab-githost.pos
+  pos_file /var/lib/google-fluentd/pos/gitlab-githost.pos
   read_from_head true
   tag gitlab-githost
 </source>
@@ -56,7 +56,7 @@
   type tail
   format none
   path /home/git/gitlab/log/satellites.log,
-  pos_file /var/tmp/fluentd.gitlab-satellites.pos
+  pos_file /var/lib/google-fluentd/pos/gitlab-satellites.pos
   read_from_head true
   tag gitlab-satellites
 </source>
@@ -65,7 +65,7 @@
   type tail
   format none
   path /home/git/gitlab-shell/gitlab-shell.log
-  pos_file /var/tmp/fluentd.gitlab-shell.pos
+  pos_file /var/lib/google-fluentd/pos/gitlab-shell.pos
   read_from_head true
   tag gitlab-shell
 </source>

--- a/configs/config.d/jenkins.conf
+++ b/configs/config.d/jenkins.conf
@@ -4,7 +4,7 @@
   format_firstline /^\w+\s\d+,\s\d+/
   format1 /(?<message>.*)/
   path /var/log/jenkins/jenkins.log
-  pos_file /var/tmp/fluentd.jenkins.pos
+  pos_file /var/lib/google-fluentd/pos/jenkins.pos
   read_from_head true
   tag jenkins
 </source>

--- a/configs/config.d/jetty.conf
+++ b/configs/config.d/jetty.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/log/jetty/*.request.log
-  pos_file /var/tmp/fluentd.jetty-request.pos
+  pos_file /var/lib/google-fluentd/pos/jetty-request.pos
   read_from_head true
   tag jetty-request
 </source>
@@ -11,7 +11,7 @@
   type tail
   format none
   path /var/log/jetty/*.stderrout.log
-  pos_file /var/tmp/fluentd.jetty-stderrout.pos
+  pos_file /var/lib/google-fluentd/pos/jetty-stderrout.pos
   read_from_head true
   tag jetty-stderrout
 </source>
@@ -20,7 +20,7 @@
   type tail
   format none
   path /var/log/jetty/out.log
-  pos_file /var/tmp/fluentd.jetty-out.pos
+  pos_file /var/lib/google-fluentd/pos/jetty-out.pos
   read_from_head true
   tag jetty-out
 </source>

--- a/configs/config.d/joomla.conf
+++ b/configs/config.d/joomla.conf
@@ -4,7 +4,7 @@
   type tail
   format none
   path /var/www/joomla/logs/*.log
-  pos_file /var/tmp/fluentd.joomla.pos
+  pos_file /var/lib/google-fluentd/pos/joomla.pos
   read_from_head true
   tag joomla
 </source>

--- a/configs/config.d/magento.conf
+++ b/configs/config.d/magento.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/www/magento/var/log/system.log
-  pos_file /var/tmp/fluentd.magento-system.pos
+  pos_file /var/lib/google-fluentd/pos/magento-system.pos
   read_from_head true
   tag magento-system
 </source>
@@ -11,7 +11,7 @@
   type tail
   format none
   path /var/www/magento/var/log/exception.log
-  pos_file /var/tmp/fluentd.magento-exception.pos
+  pos_file /var/lib/google-fluentd/pos/magento-exception.pos
   read_from_head true
   tag magento-exception
 </source>
@@ -23,7 +23,7 @@
   format none
   # Ending with a wildcard is safe because these files shouldn't be rotated.
   path /var/www/magento/var/report/*
-  pos_file /var/tmp/fluentd.magento-report.pos
+  pos_file /var/lib/google-fluentd/pos/magento-report.pos
   read_from_head true
   tag magento-report
 </source>

--- a/configs/config.d/mediawiki.conf
+++ b/configs/config.d/mediawiki.conf
@@ -5,7 +5,7 @@
   type tail
   format none
   path /var/log/mediawiki/*.log
-  pos_file /var/tmp/fluentd.mediawiki.pos
+  pos_file /var/lib/google-fluentd/pos/mediawiki.pos
   read_from_head true
   tag mediawiki
 </source>

--- a/configs/config.d/memcached.conf
+++ b/configs/config.d/memcached.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/log/memcached.log
-  pos_file /var/tmp/fluentd.memcached.pos
+  pos_file /var/lib/google-fluentd/pos/memcached.pos
   read_from_head true
   tag memcached
 </source>

--- a/configs/config.d/mongodb.conf
+++ b/configs/config.d/mongodb.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/log/mongodb/*.log
-  pos_file /var/tmp/fluentd.mongodb.pos
+  pos_file /var/lib/google-fluentd/pos/mongodb.pos
   read_from_head true
   tag mongodb
 </source>

--- a/configs/config.d/mysql.conf
+++ b/configs/config.d/mysql.conf
@@ -6,7 +6,7 @@
   # logs that have them to the logs that don't.
   format none
   path /var/log/mysql.log,/var/log/mysql/mysql.log
-  pos_file /var/tmp/fluentd.mysql.pos
+  pos_file /var/lib/google-fluentd/pos/mysql.pos
   refresh_interval 60
   read_from_head true
   tag mysql
@@ -21,7 +21,7 @@
   format_firstline /^((. User)|(. Time))/
   format1 /(?<message>.*)/
   path /var/log/mysql/mysql-slow.log
-  pos_file /var/tmp/fluentd.mysql-slow.pos
+  pos_file /var/lib/google-fluentd/pos/mysql-slow.pos
   refresh_interval 60
   read_from_head true
   tag mysql-slow

--- a/configs/config.d/nginx.conf
+++ b/configs/config.d/nginx.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/log/nginx/access.log
-  pos_file /var/tmp/fluentd.nginx-access.pos
+  pos_file /var/lib/google-fluentd/pos/nginx-access.pos
   read_from_head true
   tag nginx-access
 </source>
@@ -11,7 +11,7 @@
   type tail
   format none
   path /var/log/nginx/error.log
-  pos_file /var/tmp/fluentd.nginx-error.pos
+  pos_file /var/lib/google-fluentd/pos/nginx-error.pos
   read_from_head true
   tag nginx-error
 </source>

--- a/configs/config.d/postgresql.conf
+++ b/configs/config.d/postgresql.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/log/postgres*/*.log,/var/log/pgsql/*.log
-  pos_file /var/tmp/fluentd.postgresql.pos
+  pos_file /var/lib/google-fluentd/pos/postgresql.pos
   read_from_head true
   tag postgresql
 </source>

--- a/configs/config.d/puppet-enterprise.conf
+++ b/configs/config.d/puppet-enterprise.conf
@@ -7,7 +7,7 @@
   type tail
   format none
   path /var/log/pe-httpd/access.log
-  pos_file /var/tmp/fluentd.puppet-access.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-access.pos
   read_from_head true
   tag puppet-access
 </source>
@@ -16,7 +16,7 @@
   type tail
   format none
   path /var/log/pe-httpd/puppetmasteraccess.log
-  pos_file /var/tmp/fluentd.puppet-puppetmasteraccess.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-puppetmasteraccess.pos
   read_from_head true
   tag puppet-puppetmasteraccess
 </source>
@@ -27,7 +27,7 @@
   type tail
   format none
   path /var/log/pe-activemq/activemq.log
-  pos_file /var/tmp/fluentd.puppet-activemq.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-activemq.pos
   read_from_head true
   tag puppet-activemq
 </source>
@@ -36,7 +36,7 @@
   type tail
   format none
   path /var/log/pe-activemq/wrapper.log
-  pos_file /var/tmp/fluentd.puppet-activemq-wrapper.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-activemq-wrapper.pos
   read_from_head true
   tag puppet-activemq-wrapper
 </source>
@@ -47,7 +47,7 @@
   type tail
   format none
   path /var/log/pe-mcollective/mcollective.log
-  pos_file /var/tmp/fluentd.puppet-mcollective.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-mcollective.pos
   read_from_head true
   tag puppet-mcollective
 </source>
@@ -56,7 +56,7 @@
   type tail
   format none
   path /var/log/pe-mcollective/mcollective_audit.log
-  pos_file /var/tmp/fluentd.puppet-mcollective-audit.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-mcollective-audit.pos
   read_from_head true
   tag puppet-mcollective-audit
 </source>
@@ -67,7 +67,7 @@
   type tail
   format none
   path /var/log/pe-puppetdb/pe-puppetdb.log
-  pos_file /var/tmp/fluentd.puppet-puppetdb.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-puppetdb.pos
   read_from_head true
   tag puppet-puppetdb
 </source>
@@ -78,7 +78,7 @@
   type tail
   format none
   path /var/log/pe-httpd/puppetdashboard.error.log
-  pos_file /var/tmp/fluentd.puppet-dashboard-error.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-error.pos
   read_from_head true
   tag puppet-dashboard-error
 </source>
@@ -87,7 +87,7 @@
   type tail
   format none
   path /var/log/pe-puppet-dashboard/mcollective_client.log
-  pos_file /var/tmp/fluentd.puppet-dashboard-mcollective-client.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-mcollective-client.pos
   read_from_head true
   tag puppet-dashboard-mcollective-client
 </source>
@@ -96,7 +96,7 @@
   type tail
   format none
   path /var/log/pe-puppet-dashboard/production.log
-  pos_file /var/tmp/fluentd.puppet-dashboard-production.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-production.pos
   read_from_head true
   tag puppet-dashboard-production
 </source>
@@ -105,7 +105,7 @@
   type tail
   format none
   path /var/log/pe-puppet-dashboard/event-inspector.log
-  pos_file /var/tmp/fluentd.puppet-dashboard-event-inspector.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-event-inspector.pos
   read_from_head true
   tag puppet-dashboard-event-inspector
 </source>
@@ -114,7 +114,7 @@
   type tail
   format none
   path /var/log/pe-puppet-dashboard/certificate_manager.log
-  pos_file /var/tmp/fluentd.puppet-dashboard-certificate-manager.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-certificate-manager.pos
   read_from_head true
   tag puppet-dashboard-certificate-manager
 </source>
@@ -123,7 +123,7 @@
   type tail
   format none
   path /var/log/pe-puppet-dashboard/live-management.log
-  pos_file /var/tmp/fluentd.puppet-dashboard-live-management.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-live-management.pos
   read_from_head true
   tag puppet-dashboard-live-management
 </source>
@@ -132,7 +132,7 @@
   type tail
   format none
   path /var/log/pe-console-auth/cas_client.log
-  pos_file /var/tmp/fluentd.puppet-console-cas-client.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-console-cas-client.pos
   read_from_head true
   tag puppet-console-cas-client
 </source>
@@ -141,7 +141,7 @@
   type tail
   format none
   path /var/log/pe-console-auth/cas.log
-  pos_file /var/tmp/fluentd.puppet-console-auth-cas.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-console-auth-cas.pos
   read_from_head true
   tag puppet-console-auth-cas
 </source>
@@ -150,7 +150,7 @@
   type tail
   format none
   path /var/log/pe-console-auth/auth.log
-  pos_file /var/tmp/fluentd.puppet-console-auth.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-console-auth.pos
   read_from_head true
   tag puppet-console-auth
 </source>
@@ -159,7 +159,7 @@
   type tail
   format none
   path /var/log/pe-httpd/puppetdashboard.access.log
-  pos_file /var/tmp/fluentd.puppet-dashboard-access.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-access.pos
   read_from_head true
   tag puppet-dashboard-access
 </source>
@@ -168,7 +168,7 @@
   type tail
   format none
   path /var/log/pe-puppet-dashboard/failed_reports.log
-  pos_file /var/tmp/fluentd.puppet-dashboard-failed-reports.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-failed-reports.pos
   read_from_head true
   tag puppet-dashboard-failed-reports
 </source>
@@ -177,7 +177,7 @@
   type tail
   format none
   path /var/log/pe-httpd/error.log
-  pos_file /var/tmp/fluentd.puppet-error.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-error.pos
   read_from_head true
   tag puppet-error
 </source>
@@ -188,7 +188,7 @@
   type tail
   format none
   path /var/log/pe-httpd/other_vhosts_access.log
-  pos_file /var/tmp/fluentd.puppet-other-vhosts-access.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-other-vhosts-access.pos
   read_from_head true
   tag puppet-other-vhosts-access
 </source>
@@ -197,7 +197,7 @@
   type tail
   format none
   path /var/log/pe-puppet/masterhttp.log
-  pos_file /var/tmp/fluentd.puppet-masterhttp.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-masterhttp.pos
   read_from_head true
   tag puppet-masterhttp
 </source>
@@ -206,7 +206,7 @@
   type tail
   format none
   path /var/log/pe-puppet/rails.log
-  pos_file /var/tmp/fluentd.puppet-rails.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-rails.pos
   read_from_head true
   tag puppet-rails
 </source>

--- a/configs/config.d/puppet.conf
+++ b/configs/config.d/puppet.conf
@@ -4,7 +4,7 @@
   format_firstline /^\[\d+/
   format1 /(?<message>.*)/
   path /var/log/puppet/masterhttp.log
-  pos_file /var/tmp/fluentd.puppet-masterhttp.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-masterhttp.pos
   read_from_head true
   tag puppet-masterhttp
 </source>
@@ -15,7 +15,7 @@
   format_firstline /^\[\d+/
   format1 /(?<message>.*)/
   path /var/log/puppet/http.log
-  pos_file /var/tmp/fluentd.puppet-http.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-http.pos
   read_from_head true
   tag puppet-http
 </source>

--- a/configs/config.d/rabbitmq.conf
+++ b/configs/config.d/rabbitmq.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/log/rabbitmq/startup_log
-  pos_file /var/tmp/fluentd.rabbitmq-startup.pos
+  pos_file /var/lib/google-fluentd/pos/rabbitmq-startup.pos
   read_from_head true
   tag rabbitmq-startup
 </source>
@@ -11,7 +11,7 @@
   type tail
   format none
   path /var/log/rabbitmq/startup_err
-  pos_file /var/tmp/fluentd.rabbitmq-startup_err.pos
+  pos_file /var/lib/google-fluentd/pos/rabbitmq-startup_err.pos
   read_from_head true
   tag rabbitmq-startup_err
 </source>
@@ -23,7 +23,7 @@
   format_firstline /^=\w+ REPORT====/
   format1 /(?<message>.*)/
   path /var/log/rabbitmq/*-sasl.log
-  pos_file /var/tmp/fluentd.rabbitmq-sasl.pos
+  pos_file /var/lib/google-fluentd/pos/rabbitmq-sasl.pos
   read_from_head true
   tag rabbitmq-sasl
 </source>
@@ -37,7 +37,7 @@
   format_firstline /^=\w+ REPORT====/
   format1 /(?<message>.*)/
   path /var/log/rabbitmq/*.log
-  pos_file /var/tmp/fluentd.rabbitmq.pos
+  pos_file /var/lib/google-fluentd/pos/rabbitmq.pos
   read_from_head true
   tag rabbitmq
 </source>

--- a/configs/config.d/redis.conf
+++ b/configs/config.d/redis.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/log/redis*.log,/var/log/redis/*.log
-  pos_file /var/tmp/fluentd.redis.pos
+  pos_file /var/lib/google-fluentd/pos/redis.pos
   read_from_head true
   tag redis
 </source>

--- a/configs/config.d/redmine.conf
+++ b/configs/config.d/redmine.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/log/redmine/*.log
-  pos_file /var/tmp/fluentd.redmine.pos
+  pos_file /var/lib/google-fluentd/pos/redmine.pos
   read_from_head true
   tag redmine
 </source>

--- a/configs/config.d/salt.conf
+++ b/configs/config.d/salt.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/log/salt/master
-  pos_file /var/tmp/fluentd.salt-master.pos
+  pos_file /var/lib/google-fluentd/pos/salt-master.pos
   read_from_head true
   tag salt-master
 </source>
@@ -11,7 +11,7 @@
   type tail
   format none
   path /var/log/salt/minion
-  pos_file /var/tmp/fluentd.salt-minion.pos
+  pos_file /var/lib/google-fluentd/pos/salt-minion.pos
   read_from_head true
   tag salt-minion
 </source>
@@ -20,7 +20,7 @@
   type tail
   format none
   path /var/log/salt/key
-  pos_file /var/tmp/fluentd.salt-key.pos
+  pos_file /var/lib/google-fluentd/pos/salt-key.pos
   read_from_head true
   tag salt-key
 </source>
@@ -29,7 +29,7 @@
   type tail
   format none
   path /var/log/salt/syndic.loc
-  pos_file /var/tmp/fluentd.salt-syndic.pos
+  pos_file /var/lib/google-fluentd/pos/salt-syndic.pos
   read_from_head true
   tag salt-syndic
 </source>

--- a/configs/config.d/solr.conf
+++ b/configs/config.d/solr.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/log/solr/*.log
-  pos_file /var/tmp/fluentd.solr.pos
+  pos_file /var/lib/google-fluentd/pos/solr.pos
   read_from_head true
   tag solr
 </source>

--- a/configs/config.d/sugarcrm.conf
+++ b/configs/config.d/sugarcrm.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/www/*/sugarcrm.log
-  pos_file /var/tmp/fluentd.sugarcrm.pos
+  pos_file /var/lib/google-fluentd/pos/sugarcrm.pos
   read_from_head true
   tag sugarcrm
 </source>

--- a/configs/config.d/syslog.conf
+++ b/configs/config.d/syslog.conf
@@ -5,7 +5,7 @@
   format /^(?<message>(?<time>[^ ]*\s*[^ ]* [^ ]*) .*)$/
 
   path /var/log/syslog
-  pos_file /var/tmp/fluentd.syslog.pos
+  pos_file /var/lib/google-fluentd/pos/syslog.pos
   read_from_head true
   tag syslog
 </source>

--- a/configs/config.d/tomcat.conf
+++ b/configs/config.d/tomcat.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/log/tomcat*/localhost_access_log.%Y-%m-%d.txt
-  pos_file /var/tmp/fluentd.tomcat.pos
+  pos_file /var/lib/google-fluentd/pos/tomcat.pos
   read_from_head true
   tag tomcat-localhost_access_log
 </source>
@@ -15,7 +15,7 @@
   format_firstline /^(\w+\s\d+,\s\d+)|(\d+-\d+-\d+\s)/
   format1 /(?<message>.*)/
   path /var/log/tomcat*/catalina.out,/var/log/tomcat*/localhost.*.log
-  pos_file /var/tmp/fluentd.tomcat-multiline.pos
+  pos_file /var/lib/google-fluentd/pos/tomcat-multiline.pos
   read_from_head true
   tag tomcat
 </source>

--- a/configs/config.d/zookeeper.conf
+++ b/configs/config.d/zookeeper.conf
@@ -2,7 +2,7 @@
   type tail
   format none
   path /var/log/zookeeper/zookeeper.log
-  pos_file /var/tmp/fluentd.zookeeper.pos
+  pos_file /var/lib/google-fluentd/pos/zookeeper.pos
   read_from_head true
   tag zookeeper
 </source>
@@ -11,7 +11,7 @@
   type tail
   format none
   path /var/log/zookeeper/zookeeper_trace.log
-  pos_file /var/tmp/fluentd.zookeeper-trace.pos
+  pos_file /var/lib/google-fluentd/pos/zookeeper-trace.pos
   read_from_head true
   tag zookeeper-trace
 </source>

--- a/pkg/el/google-fluentd-catch-all-config.spec
+++ b/pkg/el/google-fluentd-catch-all-config.spec
@@ -16,6 +16,7 @@ from the system and third-party application packages.
 %files
 %dir /etc/google-fluentd
 %config(noreplace) /etc/google-fluentd
+%dir /var/lib/google-fluentd/pos
 
 %clean
 # don't clean up the files here; we'll do it in the toplevel Makefile


### PR DESCRIPTION
- the new location is preferable since it's controlled by root and
  persists across reboots.
- remove the 'fluentd.' prefix from all pos_files since it's somewhat
  redundant now.
