### PR TITLE
Allow 'access_log' and 'error_log' for apache logs.

### DIFF
--- a/configs/config.d/apache.conf
+++ b/configs/config.d/apache.conf
@@ -1,7 +1,7 @@
 <source>
   type tail
   format none
-  path /var/log/apache*/access.log,/var/log/httpd/access.log
+  path /var/log/apache*/access.log,/var/log/apache*/access_log,/var/log/httpd/access.log,/var/log/httpd/access_log
   pos_file /var/lib/google-fluentd/pos/apache-access.pos
   read_from_head true
   tag apache-access
@@ -10,7 +10,7 @@
 <source>
   type tail
   format none
-  path /var/log/apache*/error.log,/var/log/httpd/error.log
+  path /var/log/apache*/error.log,/var/log/apache*/error_log,/var/log/httpd/error.log,/var/log/httpd/error_log
   pos_file /var/lib/google-fluentd/pos/apache-error.pos
   read_from_head true
   tag apache-error


### PR DESCRIPTION
CentOS and RHEL's default apache install (httpd) uses underscores
instead of dots for these log files.

This probably only applies to /var/log/httpd but it can't hurt to
do it for /var/log/apache\* as well.

See https://github.com/GoogleCloudPlatform/fluentd-catch-all-config/issues/4

I checked all supported platforms - versions 6 and 7 of both CentOS and RHEL.
