### PR TITLE
Accept structured logs data over TCP by default.

### DIFF
--- a/configs/config.d/forward.conf
+++ b/configs/config.d/forward.conf
@@ -1,6 +1,7 @@
 <source>
   @type forward
+  # default port
   port 24224
-  # only accepts connections from localhost - to open this up, change to 0.0.0.0
+  # only accept connections from localhost - to open this up, change to 0.0.0.0
   bind 127.0.0.1
 </source>

--- a/configs/config.d/forward.conf
+++ b/configs/config.d/forward.conf
@@ -1,0 +1,6 @@
+<source>
+  @type forward
+  port 24224
+  # only accepts connections from localhost - to open this up, change to 0.0.0.0
+  bind 127.0.0.1
+</source>


### PR DESCRIPTION
To collect application-level logs, the fluentd documentation recommends
using the forward input plugin for all languages except PHP, see
http://docs.fluentd.org/v0.12/categories/logging-from-apps. By adding
this file, the story for sending application-level logs to Cloud Logging
becomes much easier.
