### PR TITLE
Use unique pos file paths for Puppet Enterprise.

### DIFF
--- a/configs/config.d/puppet-enterprise.conf
+++ b/configs/config.d/puppet-enterprise.conf
@@ -7,7 +7,7 @@
   @type tail
   format none
   path /var/log/pe-httpd/access.log
-  pos_file /var/lib/google-fluentd/pos/puppet-access.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-access.pos
   read_from_head true
   tag puppet-access
 </source>
@@ -16,7 +16,7 @@
   @type tail
   format none
   path /var/log/pe-httpd/puppetmasteraccess.log
-  pos_file /var/lib/google-fluentd/pos/puppet-puppetmasteraccess.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-puppetmasteraccess.pos
   read_from_head true
   tag puppet-puppetmasteraccess
 </source>
@@ -27,7 +27,7 @@
   @type tail
   format none
   path /var/log/pe-activemq/activemq.log
-  pos_file /var/lib/google-fluentd/pos/puppet-activemq.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-activemq.pos
   read_from_head true
   tag puppet-activemq
 </source>
@@ -36,7 +36,7 @@
   @type tail
   format none
   path /var/log/pe-activemq/wrapper.log
-  pos_file /var/lib/google-fluentd/pos/puppet-activemq-wrapper.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-activemq-wrapper.pos
   read_from_head true
   tag puppet-activemq-wrapper
 </source>
@@ -47,7 +47,7 @@
   @type tail
   format none
   path /var/log/pe-mcollective/mcollective.log
-  pos_file /var/lib/google-fluentd/pos/puppet-mcollective.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-mcollective.pos
   read_from_head true
   tag puppet-mcollective
 </source>
@@ -56,7 +56,7 @@
   @type tail
   format none
   path /var/log/pe-mcollective/mcollective_audit.log
-  pos_file /var/lib/google-fluentd/pos/puppet-mcollective-audit.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-mcollective-audit.pos
   read_from_head true
   tag puppet-mcollective-audit
 </source>
@@ -67,7 +67,7 @@
   @type tail
   format none
   path /var/log/pe-puppetdb/pe-puppetdb.log
-  pos_file /var/lib/google-fluentd/pos/puppet-puppetdb.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-puppetdb.pos
   read_from_head true
   tag puppet-puppetdb
 </source>
@@ -78,7 +78,7 @@
   @type tail
   format none
   path /var/log/pe-httpd/puppetdashboard.error.log
-  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-error.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-dashboard-error.pos
   read_from_head true
   tag puppet-dashboard-error
 </source>
@@ -87,7 +87,7 @@
   @type tail
   format none
   path /var/log/pe-puppet-dashboard/mcollective_client.log
-  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-mcollective-client.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-dashboard-mcollective-client.pos
   read_from_head true
   tag puppet-dashboard-mcollective-client
 </source>
@@ -96,7 +96,7 @@
   @type tail
   format none
   path /var/log/pe-puppet-dashboard/production.log
-  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-production.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-dashboard-production.pos
   read_from_head true
   tag puppet-dashboard-production
 </source>
@@ -105,7 +105,7 @@
   @type tail
   format none
   path /var/log/pe-puppet-dashboard/event-inspector.log
-  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-event-inspector.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-dashboard-event-inspector.pos
   read_from_head true
   tag puppet-dashboard-event-inspector
 </source>
@@ -114,7 +114,7 @@
   @type tail
   format none
   path /var/log/pe-puppet-dashboard/certificate_manager.log
-  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-certificate-manager.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-dashboard-certificate-manager.pos
   read_from_head true
   tag puppet-dashboard-certificate-manager
 </source>
@@ -123,7 +123,7 @@
   @type tail
   format none
   path /var/log/pe-puppet-dashboard/live-management.log
-  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-live-management.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-dashboard-live-management.pos
   read_from_head true
   tag puppet-dashboard-live-management
 </source>
@@ -132,7 +132,7 @@
   @type tail
   format none
   path /var/log/pe-console-auth/cas_client.log
-  pos_file /var/lib/google-fluentd/pos/puppet-console-cas-client.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-console-cas-client.pos
   read_from_head true
   tag puppet-console-cas-client
 </source>
@@ -141,7 +141,7 @@
   @type tail
   format none
   path /var/log/pe-console-auth/cas.log
-  pos_file /var/lib/google-fluentd/pos/puppet-console-auth-cas.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-console-auth-cas.pos
   read_from_head true
   tag puppet-console-auth-cas
 </source>
@@ -150,7 +150,7 @@
   @type tail
   format none
   path /var/log/pe-console-auth/auth.log
-  pos_file /var/lib/google-fluentd/pos/puppet-console-auth.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-console-auth.pos
   read_from_head true
   tag puppet-console-auth
 </source>
@@ -159,7 +159,7 @@
   @type tail
   format none
   path /var/log/pe-httpd/puppetdashboard.access.log
-  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-access.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-dashboard-access.pos
   read_from_head true
   tag puppet-dashboard-access
 </source>
@@ -168,7 +168,7 @@
   @type tail
   format none
   path /var/log/pe-puppet-dashboard/failed_reports.log
-  pos_file /var/lib/google-fluentd/pos/puppet-dashboard-failed-reports.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-dashboard-failed-reports.pos
   read_from_head true
   tag puppet-dashboard-failed-reports
 </source>
@@ -177,7 +177,7 @@
   @type tail
   format none
   path /var/log/pe-httpd/error.log
-  pos_file /var/lib/google-fluentd/pos/puppet-error.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-error.pos
   read_from_head true
   tag puppet-error
 </source>
@@ -188,7 +188,7 @@
   @type tail
   format none
   path /var/log/pe-httpd/other_vhosts_access.log
-  pos_file /var/lib/google-fluentd/pos/puppet-other-vhosts-access.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-other-vhosts-access.pos
   read_from_head true
   tag puppet-other-vhosts-access
 </source>
@@ -197,7 +197,7 @@
   @type tail
   format none
   path /var/log/pe-puppet/masterhttp.log
-  pos_file /var/lib/google-fluentd/pos/puppet-masterhttp.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-masterhttp.pos
   read_from_head true
   tag puppet-masterhttp
 </source>
@@ -206,7 +206,7 @@
   @type tail
   format none
   path /var/log/pe-puppet/rails.log
-  pos_file /var/lib/google-fluentd/pos/puppet-rails.pos
+  pos_file /var/lib/google-fluentd/pos/puppet-enterprise-rails.pos
   read_from_head true
   tag puppet-rails
 </source>


### PR DESCRIPTION
Starting with Fluentd `v0.14.22`, pos file uniqueness check has been added: https://github.com/fluent/fluentd/commit/d6761a8b19846d34fd9f384cb9a6f297f11db6bb.

Our existing configs violates this check and result in config errors because `puppet.conf` and `puppet-enterprise.conf` share exactly the same pos file `/var/lib/google-fluentd/pos/puppet-masterhttp.pos`:
```
2018-02-20 22:12:00 +0000 [error]: config error file="/etc/google-fluentd/google-fluentd.conf" error_class=Fluent::
ConfigError error="Other 'in_tail' plugin already use same pos_file path: plugin_id = object:3fdfd66b8f14, pos_file
 path = /var/lib/google-fluentd/pos/puppet-masterhttp.pos"
```