### PR TITLE
Fix parsing of MySQL slow query logs.

### DIFF
--- a/configs/config.d/mysql.conf
+++ b/configs/config.d/mysql.conf
@@ -18,7 +18,7 @@
   # This would be better if we could use # symbols in the format regex without
   # requiring the V1 config format to be used, but using dots seems preferable
   # to requiring that.
-  format_firstline /^((. User)|(. Time))/
+  format_firstline /^(. Time))/
   format1 /(?<message>.*)/
   multiline_flush_interval 5s
   path /var/log/mysql/mysql-slow.log


### PR DESCRIPTION
Assume that all slow query log entries start with a timestamp.