### PR TITLE
Init baseline configs for config usage analysis comparison.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,18 @@ el-tar: populate-el
 populate-deb:
 	# populate config files
 	mkdir -p ${DEB_FILES_DIR}
+	mkdir -p ${DEB_FILES_DIR}/baseline
 	cp -a configs/* ${DEB_FILES_DIR}
+	cp -a configs/* ${DEB_FILES_DIR}/baseline
 	# create the directory used for "pos_file"s
 	mkdir -p ${DEB_POS_FILES_DIR}
 
 populate-el:
 	# populate config files
 	mkdir -p ${EL_FILES_DIR}
+	mkdir -p ${EL_FILES_DIR}/baseline
 	cp -a configs/* ${EL_FILES_DIR}
+	cp -a configs/* ${EL_FILES_DIR}/baseline
 	# create the directory used for "pos_file"s
 	mkdir -p ${EL_POS_FILES_DIR}
 


### PR DESCRIPTION
This goes together with https://github.com/GoogleCloudPlatform/google-fluentd/pull/304.

The use cases we need to cover:

Case 1

Users install the google-fluentd package only. They may:
* Modify the google-fluentd.conf file (including making it include more directories / files)
* Add additional files to the conf.d folder
* Add additional files in other folders

In this case, the baseline configs should always only include the original google-fluentd.conf

Case 2

Users install both the google-fluentd package and the catch-all-config package. They may:
* Modify the google-fluentd.conf file (including making it include more directories / files)
* Modify existing files in the conf.d folder
* Add additional files to the conf.d folder
* Add additional files in other folders

In this case, the baseline configs should always only include the original google-fluentd.conf and the files we provide for the conf.d folder.